### PR TITLE
fix: change type of version field to String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Export `const VERSION`.
+
+## [0.4.0] - 2023-08-12
+
+### Changed
+
+- Changes type of `VaultStandardInfoResponse::version` from `u16` to `String`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,7 @@ dependencies = [
 
 [[package]]
 name = "cw-vault-standard"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-vault-standard"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 authors = ["Sturdy <sturdy@apollo.farm>"]
 license = "Apache-2.0"

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -186,8 +186,9 @@ pub enum ExtensionQueryMsg {
 /// instead of needing to do a costly SmartQuery.
 #[cw_serde]
 pub struct VaultStandardInfoResponse {
-    /// The version of the vault standard used. A number, e.g. 1, 2, etc.
-    pub version: u16,
+    /// The version of the vault standard used by the vault as a semver compliant
+    /// string. E.g. "1.0.0" or "1.2.3-alpha.1"
+    pub version: String,
     /// A list of vault standard extensions used by the vault.
     /// E.g. ["lockup", "keeper"]
     pub extensions: Vec<String>,


### PR DESCRIPTION
Changes type of `VaultStandardInfoResponse::version` to String